### PR TITLE
Delete load balancers before removing VPC

### DIFF
--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -72,6 +72,20 @@ do
         --region ${AWS_REGION}
 done
 
+# Delete Load Balancers
+echo "Process of Load Balancers ..."
+for load_balancer in $(aws elb describe-load-balancers \
+    --region ${AWS_REGION} | \
+    jq -r ".LoadBalancerDescriptions[] | select(.VPCId == \"${VPC_ID}\") | \
+    .LoadBalancerName" \
+    )
+do
+    echo "    delete Load Balancer of $load_balancer"
+    aws elb delete-load-balancer \
+        --load-balancer-name ${load_balancer} \
+        --region ${AWS_REGION} > /dev/null
+done
+
 # Delete NAT Gateway
 echo "Process of NAT Gateway ..."
 for natgateway in $(aws ec2 describe-nat-gateways \


### PR DESCRIPTION
If there is any elastic load balancer that holds network interfaces, it is not possible for NAT/Internet gateways to delete the NICs.
As a result a VPC that depends on the gateways cannot be deleted as well.

So we should remove every elastic load balancer, before removing VPCs.

As `aws elb load-balancers` does not support `--filters` option, we should rely on pure jq filters.