### PR TITLE
Allow api termination

### DIFF
--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -123,7 +123,7 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
-    echo "    enable api termination of $instance"
+    echo "    enable api stop of $instance"
     aws ec2 modify-instance-attribute \
         --no-disable-api-stop \
         --instance-id "${instance}" \

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -42,11 +42,11 @@ if [ ${state} != 'available' ]; then
     exit 1
 fi
 
-# echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
-# read answer
-# if [ "$answer" != "${answer#[Nn]}" ] ;then
-#     exit 1
-# fi
+echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
+read answer
+if [ "$answer" != "${answer#[Nn]}" ] ;then
+    exit 1
+fi
 
 # Delete ELB
 echo "Process of ELB ..."

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -42,11 +42,11 @@ if [ ${state} != 'available' ]; then
     exit 1
 fi
 
-echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
-read answer
-if [ "$answer" != "${answer#[Nn]}" ] ;then
-    exit 1
-fi
+# echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
+# read answer
+# if [ "$answer" != "${answer#[Nn]}" ] ;then
+#     exit 1
+# fi
 
 # Delete ELB
 echo "Process of ELB ..."
@@ -123,6 +123,18 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
+    echo "    enable api termination of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-stop \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+
+        echo "    enable api termination of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-termination \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+
     echo "    terminate instance of $instance"
     aws ec2 terminate-instances \
         --instance-ids "${instance}" \

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -105,6 +105,13 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
+
+    echo "    enable api stop of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-stop \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+        
     echo "    stop instance of $instance"
     aws ec2 stop-instances \
         --instance-ids "${instance}" \
@@ -123,11 +130,6 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
-    echo "    enable api stop of $instance"
-    aws ec2 modify-instance-attribute \
-        --no-disable-api-stop \
-        --instance-id "${instance}" \
-        --region "${AWS_REGION}" > /dev/null
 
         echo "    enable api termination of $instance"
     aws ec2 modify-instance-attribute \


### PR DESCRIPTION
This PR allows EC2 instances with `disable-api-stop` and `disable-api-termination` to be stopped and terminated. 