### PR TITLE
Non interactive

### DIFF
--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -123,7 +123,7 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
-    echo "    enable api termination of $instance"
+    echo "    enable api stop of $instance"
     aws ec2 modify-instance-attribute \
         --no-disable-api-stop \
         --instance-id "${instance}" \

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -12,8 +12,9 @@ if ! command -v aws &>/dev/null; then
 fi
 
 if [ -z "$1" ]; then
-    echo "Usage   : $0 <aws region> <vpc id>"
+    echo "Usage   : $0 <aws region> <vpc id> [--non-interactive]"
     echo "Example : $0 us-east-1 vpc-xxxxxxxxxx"
+    echo "Example : $0 us-east-1 vpc-xxxxxxxxxx --non-interactive"
     echo ""
     exit 1
 fi
@@ -30,6 +31,13 @@ else
     VPC_ID=$2
 fi
 
+NON_INTERACTIVE=0
+for arg in "$@"; do
+  if [ $arg = '--non-interactive' ]; then
+    NON_INTERACTIVE=1
+  fi
+done
+
 # Check VPC state, available or not
 state=$(aws ec2 describe-vpcs \
     --vpc-ids "${VPC_ID}" \
@@ -42,10 +50,12 @@ if [ ${state} != 'available' ]; then
     exit 1
 fi
 
-echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
-read answer
-if [ "$answer" != "${answer#[Nn]}" ] ;then
-    exit 1
+if [ $NON_INTERACTIVE -eq 0 ]  ;then
+  echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
+  read answer
+  if [ "$answer" != "${answer#[Nn]}" ] ;then
+      exit 1
+  fi
 fi
 
 # Delete ELB

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -42,11 +42,11 @@ if [ ${state} != 'available' ]; then
     exit 1
 fi
 
-# echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
-# read answer
-# if [ "$answer" != "${answer#[Nn]}" ] ;then
-#     exit 1
-# fi
+echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
+read answer
+if [ "$answer" != "${answer#[Nn]}" ] ;then
+    exit 1
+fi
 
 # Delete ELB
 echo "Process of ELB ..."

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -42,11 +42,11 @@ if [ ${state} != 'available' ]; then
     exit 1
 fi
 
-echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
-read answer
-if [ "$answer" != "${answer#[Nn]}" ] ;then
-    exit 1
-fi
+# echo -n "*** Are you sure to delete the VPC of ${VPC_ID} in ${AWS_REGION} (y/n)? "
+# read answer
+# if [ "$answer" != "${answer#[Nn]}" ] ;then
+#     exit 1
+# fi
 
 # Delete ELB
 echo "Process of ELB ..."
@@ -123,6 +123,18 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
+    echo "    enable api termination of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-stop \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+
+        echo "    enable api termination of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-termination \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+
     echo "    terminate instance of $instance"
     aws ec2 terminate-instances \
         --instance-ids "${instance}" \

--- a/delete_vpc.sh
+++ b/delete_vpc.sh
@@ -105,6 +105,13 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
+
+    echo "    enable api stop of $instance"
+    aws ec2 modify-instance-attribute \
+        --no-disable-api-stop \
+        --instance-id "${instance}" \
+        --region "${AWS_REGION}" > /dev/null
+        
     echo "    stop instance of $instance"
     aws ec2 stop-instances \
         --instance-ids "${instance}" \
@@ -123,11 +130,6 @@ for instance in $(aws ec2 describe-instances \
     --output text \
     --region "${AWS_REGION}")
 do
-    echo "    enable api stop of $instance"
-    aws ec2 modify-instance-attribute \
-        --no-disable-api-stop \
-        --instance-id "${instance}" \
-        --region "${AWS_REGION}" > /dev/null
 
         echo "    enable api termination of $instance"
     aws ec2 modify-instance-attribute \


### PR DESCRIPTION
PR adds an option `--non-interactive` which allows the script to run without confirming deletion of vpc. This allows it to run in non-interactive or automated scripts. 